### PR TITLE
Fixed update check URL

### DIFF
--- a/CleanShotX/CleanShotX.download.recipe
+++ b/CleanShotX/CleanShotX.download.recipe
@@ -20,17 +20,21 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>appcast_url</key>
-				<string>https://updates.getcleanshot.com/v3/appcast.xml</string>
+				<key>re_pattern</key>
+				<string>(?m)&#x3C;div class=&#x22;version&#x22;.+?&#x3E;(\d+\.\d+(?:\.\d)*)&#x3C;/div&#x3E;</string>
+				<key>url</key>
+				<string>https://cleanshot.com/changelog</string>
 			</dict>
 			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
+			<string>URLTextSearcher</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.dmg</string>
+				<string>%NAME%-%match%.dmg</string>
+				<key>url</key>
+				<string>https://updates.getcleanshot.com/v3/CleanShot-X-%match%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
The previous URL was pulled from the SparkleFeed XML which hasn't been updated since 2021.

This update swaps the SparkleFeed for scraping the version number from their changelog at https://cleanshot.com/changelog and building the download URL using the extracted version.

I went this route after failing to find another public update feed. Checking for updates and monitoring with a proxy yielded this URL: `https://legit.maketheweb.io/api/v1/check-for-updates?key=<LICENSE_KEY_REDACTED>&version=4.8.7` which would require submitting a license key.

The regex parsing the HTML is `(?m)<div class="version".+?>(\d+\.\d+(?:\.\d)*)</div>`. I then encoded the HTML to make it save to place inside an XML string, yielding `<string>(?m)&#x3C;div class=&#x22;version&#x22;.+?&#x3E;(\d+\.\d+(?:\.\d)*)&#x3C;/div&#x3E;</string>`

After testing this appears to work and downloads the latest CleanShot X as `CleanShot X-4.8.7.dmg`