### PR TITLE
Update NetBird Developer ID

### DIFF
--- a/NetBird/NetBird.download.recipe
+++ b/NetBird/NetBird.download.recipe
@@ -48,7 +48,7 @@
 				<string>%pathname%</string>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: Wiretrustee UG (haftungsbeschrankt) (TA739QLA7A)</string>
+					<string>Developer ID Installer: NetBird GmbH (TA739QLA7A)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
Hi @bryanheinz,

The certificate (Developer ID) name of NetBird has changed, causing the download recipe to fail. This PR fixes the `CodeSignatureVerifier` entry.

Please see the output of `autopkg run -vvq NetBird.download.recipe`:
```
Processing NetBird.download.recipe...
WARNING: NetBird.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'netbirdio/netbird'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: No value supplied for GITHUB_RELEASES_PER_PAGE, setting default value of: 30
GitHubReleasesInfoProvider: Fetching page 1 of GitHub releases
GitHubReleasesInfoProvider: Selected asset 'getting-started-with-zitadel.sh' from release 'v0.70.4'
{'Output': {'asset_created_at': '2026-04-29T22:46:26Z',
            'asset_url': 'https://api.github.com/repos/netbirdio/netbird/releases/assets/408550288',
            'release_notes': "## What's Changed\r\n"
                             '* [misc] fix MSI generation add installer tests '
                             'by @mlsmaycon in '
                             'https://github.com/netbirdio/netbird/pull/6031\r\n'
                             '\r\n'
                             '\r\n'
                             '**Full Changelog**: '
                             'https://github.com/netbirdio/netbird/compare/v0.70.3...v0.70.4',
            'url': 'https://github.com/netbirdio/netbird/releases/download/v0.70.4/getting-started-with-zitadel.sh',
            'version': '0.70.4'}}
URLDownloader
{'Input': {'url': 'https://github.com/netbirdio/netbird/releases/download/v0.70.4/netbird_0.70.4_darwin.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 29 Apr 2026 22:52:54 GMT
URLDownloader: Storing new ETag header: "0x8DEA6420CFFDE54"
URLDownloader: Downloaded /Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/downloads/netbird_0.70.4_darwin.pkg
{'Output': {'download_changed': True,
            'etag': '"0x8DEA6420CFFDE54"',
            'last_modified': 'Wed, 29 Apr 2026 22:52:54 GMT',
            'pathname': '/Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/downloads/netbird_0.70.4_darwin.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/downloads/netbird_0.70.4_darwin.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: NetBird GmbH '
                                        '(TA739QLA7A)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/downloads/netbird_0.70.4_darwin.pkg'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "netbird_0.70.4_darwin.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2026-04-29 22:51:19 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: NetBird GmbH (TA739QLA7A)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            EC C2 47 B7 AF 5F 78 70 19 24 29 EA F2 A5 85 CD D9 D8 7E 01 B9 3E
CodeSignatureVerifier:            77 98 20 DB 67 70 18 C7 F7 B4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/receipts/NetBird.download-receipt-20260430-145039.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/downloads/netbird_0.70.4_darwin.pkg
```
