### PR TITLE
NetBird: Stable release only

### DIFF
--- a/NetBird/NetBird.download.recipe
+++ b/NetBird/NetBird.download.recipe
@@ -24,6 +24,10 @@
 			<dict>
 				<key>github_repo</key>
 				<string>%GITHUB_REPO%</string>
+				<key>asset_regex</key>
+				<string>^netbird_.*_darwin\.pkg$</string>
+				<key>latest_only</key>
+				<true/>
 			</dict>
 		</dict>
 		<dict>
@@ -32,7 +36,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://github.com/netbirdio/netbird/releases/download/v%version%/netbird_%version%_darwin.pkg</string>
+				<string>%url%</string>
 				<key>output_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%_%version%_darwin.pkg</string>
 			</dict>


### PR DESCRIPTION
Recently, a pre-release was pulled from the repo. This is probably not what you want to deploy in a Munki workflow.

Moreover, the download recipe is currently failing since it is trying to find the pkg with the highest number, being a release candidate (v0.74.0-rc.2). There exists no pkg for this release, only assets.

This PR changes that behavior by setting the `GitHubReleasesInfoProvider` option `latest_only` to true.

Also, the pkg name is retrieved by the same processor instead of assembling it in the `URLDownloader`.

Both download and munki recipe have been tested successfully.

Please see the output of `autopkg run -vvq NetBird/NetBird.download.recipe`:
```
Processing NetBird/NetBird.download.recipe...
WARNING: NetBird/NetBird.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '^netbird_.*_darwin\\.pkg$',
           'github_repo': 'netbirdio/netbird',
           'latest_only': True}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: No value supplied for GITHUB_RELEASES_PER_PAGE, setting default value of: 30
GitHubReleasesInfoProvider: Fetching page 1 of GitHub releases
GitHubReleasesInfoProvider: Matched regex '^netbird_.*_darwin\.pkg$' among asset(s): getting-started-enterprise.sh, getting-started-with-zitadel.sh, getting-started.sh, install.sh, migrate-to-enterprise.sh, netbird-idp-migrate_0.73.2_linux_amd64.tar.gz, netbird-idp-migrate_0.73.2_linux_arm.tar.gz, netbird-idp-migrate_0.73.2_linux_arm64.tar.gz, netbird-ui-linux_0.73.2_linux_amd64.tar.gz, netbird-ui-windows_0.73.2_windows_amd64.tar.gz, netbird-ui-windows_0.73.2_windows_arm64.tar.gz, netbird-ui_0.73.2_checksums.txt, netbird-ui_0.73.2_darwin_all.tar.gz, netbird-ui_0.73.2_darwin_all_signed.zip, netbird-ui_0.73.2_darwin_amd64.tar.gz, netbird-ui_0.73.2_darwin_amd64_signed.zip, netbird-ui_0.73.2_darwin_arm64.tar.gz, netbird-ui_0.73.2_darwin_arm64_signed.zip, netbird-ui_0.73.2_linux_amd64.deb, netbird-ui_0.73.2_linux_amd64.rpm, netbird-ui_darwin_checksums.txt, netbird_0.73.2.wasm, netbird_0.73.2_checksums.txt, netbird_0.73.2_darwin.pkg, netbird_0.73.2_darwin_all.tar.gz, netbird_0.73.2_darwin_amd64.pkg, netbird_0.73.2_darwin_amd64.tar.gz, netbird_0.73.2_darwin_arm64.pkg, netbird_0.73.2_darwin_arm64.tar.gz, netbird_0.73.2_linux_386.deb, netbird_0.73.2_linux_386.rpm, netbird_0.73.2_linux_386.tar.gz, netbird_0.73.2_linux_amd64.deb, netbird_0.73.2_linux_amd64.rpm, netbird_0.73.2_linux_amd64.tar.gz, netbird_0.73.2_linux_arm64.deb, netbird_0.73.2_linux_arm64.rpm, netbird_0.73.2_linux_arm64.tar.gz, netbird_0.73.2_linux_armv6.deb, netbird_0.73.2_linux_armv6.rpm, netbird_0.73.2_linux_armv6.tar.gz, netbird_0.73.2_linux_mips64le_hardfloat.tar.gz, netbird_0.73.2_linux_mips64le_softfloat.tar.gz, netbird_0.73.2_linux_mips64_hardfloat.tar.gz, netbird_0.73.2_linux_mips64_softfloat.tar.gz, netbird_0.73.2_linux_mipsle_hardfloat.tar.gz, netbird_0.73.2_linux_mipsle_softfloat.tar.gz, netbird_0.73.2_linux_mips_hardfloat.tar.gz, netbird_0.73.2_linux_mips_softfloat.tar.gz, netbird_0.73.2_windows_amd64.tar.gz, netbird_0.73.2_windows_amd64_signed.tar.gz, netbird_0.73.2_windows_arm64.tar.gz, netbird_0.73.2_windows_arm64_signed.tar.gz, netbird_installer_0.73.2_windows_amd64.exe, netbird_installer_0.73.2_windows_amd64.msi, netbird_installer_0.73.2_windows_arm64.exe, netbird_installer_0.73.2_windows_arm64.msi
GitHubReleasesInfoProvider: Selected asset 'netbird_0.73.2_darwin.pkg' from release 'v0.73.2'
{'Output': {'asset_created_at': '2026-06-22T19:53:48Z',
            'asset_url': 'https://api.github.com/repos/netbirdio/netbird/releases/assets/454903994',
            'release_notes': "## What's Changed\r\n"
                             '* [misc] Bump the actions group across 1 '
                             'directory with 9 updates by @dependabot[bot] in '
                             'https://github.com/netbirdio/netbird/pull/6451\r\n'
                             '* [client] Surface DNS forwarder upstream '
                             'failures via Extended DNS Errors by @lixmal in '
                             'https://github.com/netbirdio/netbird/pull/6441\r\n'
                             '* [misc] Add TARGETPLATFORM build argument to '
                             'Docker build commands by @mlsmaycon in '
                             'https://github.com/netbirdio/netbird/pull/6499\r\n'
                             '* [client] Add Auth.Stop() to cancel an '
                             'in-progress interactive login by @pappz in '
                             'https://github.com/netbirdio/netbird/pull/6486\r\n'
                             '* [client] Fix engine lifecyrcle race by @pappz '
                             'in '
                             'https://github.com/netbirdio/netbird/pull/6443\r\n'
                             '* [client] fix WaitStreamConnected test call '
                             'after ctx signature change by @pappz in '
                             'https://github.com/netbirdio/netbird/pull/6503\r\n'
                             '* [misc] Add enterprise getting-started and '
                             'migrate script by @bcmmbaga in '
                             'https://github.com/netbirdio/netbird/pull/6501\r\n'
                             '* [management] do not use meta diff for login by '
                             '@pascal-fischer in '
                             'https://github.com/netbirdio/netbird/pull/6502\r\n'
                             '* [management] validate meta change against '
                             'posture checks by @pascal-fischer in '
                             'https://github.com/netbirdio/netbird/pull/6510\r\n'
                             '* [management] empty file check in nmap on other '
                             'posturechecks by @pascal-fischer in '
                             'https://github.com/netbirdio/netbird/pull/6511\r\n'
                             '\r\n'
                             '\r\n'
                             '**Full Changelog**: '
                             'https://github.com/netbirdio/netbird/compare/v0.73.1...v0.73.2',
            'url': 'https://github.com/netbirdio/netbird/releases/download/v0.73.2/netbird_0.73.2_darwin.pkg',
            'version': '0.73.2'}}
URLDownloader
{'Input': {'url': 'https://github.com/netbirdio/netbird/releases/download/v0.73.2/netbird_0.73.2_darwin.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 22 Jun 2026 19:53:51 GMT
URLDownloader: Storing new ETag header: "0x8DED097FBBC89CF"
URLDownloader: Downloaded /Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/downloads/netbird_0.73.2_darwin.pkg
{'Output': {'download_changed': True,
            'etag': '"0x8DED097FBBC89CF"',
            'last_modified': 'Mon, 22 Jun 2026 19:53:51 GMT',
            'pathname': '/Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/downloads/netbird_0.73.2_darwin.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/downloads/netbird_0.73.2_darwin.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: NetBird GmbH '
                                        '(TA739QLA7A)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/downloads/netbird_0.73.2_darwin.pkg'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "netbird_0.73.2_darwin.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2026-06-22 19:52:20 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: NetBird GmbH (TA739QLA7A)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            EC C2 47 B7 AF 5F 78 70 19 24 29 EA F2 A5 85 CD D9 D8 7E 01 B9 3E
CodeSignatureVerifier:            77 98 20 DB 67 70 18 C7 F7 B4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to /Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/receipts/NetBird.download-receipt-20260629-093249.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/ladmin/Library/AutoPkg/Cache/com.github.bryanheinz.download.netbird/downloads/netbird_0.73.2_darwin.pkg
```